### PR TITLE
Make new problem script check whether directory already exists

### DIFF
--- a/new_problem.sh
+++ b/new_problem.sh
@@ -45,8 +45,12 @@ fi
 # get relative path to this script
 top_path="$(dirname -- "${BASH_SOURCE[0]}")"
 
-# construct path and set up problem directory
+# construct path and set up problem directory if it doesn't exist
 path="$top_path/Problems/$padded. ($2) $3/$lang"
+if [ -d "$path" ]; then
+  echo "Problem #$1 already exists at $path."
+  exit 0
+fi
 mkdir -p "$path"
 
 # change solution file extension based on supplied language


### PR DESCRIPTION
`new_problem.sh` now checks the `Problems` directory to determine whether a problem already exists.
If it does, it will now exit immediately instead of attempting to overwrite the existing problem. It also takes into account different language implementations, so if a problem exists but a language does not, it will go ahead and set up the appropriate directory for the specified problem and language.